### PR TITLE
[WIP] Add Support for email and URI base Subject Alternative Names

### DIFF
--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -63,11 +63,20 @@ type CertificateSpec struct {
 	// Certificate renew before expiration duration
 	RenewBefore *metav1.Duration `json:"renewBefore,omitempty"`
 
+	// Do not automatically add the common name as an Subject Alternative Name
+	ExcludeCommonNameFromSANs bool `json:"excludeCommonNameFromSANs,omitempty"`
+
 	// DNSNames is a list of subject alt names to be used on the Certificate
 	DNSNames []string `json:"dnsNames,omitempty"`
 
 	// IPAddresses is a list of IP addresses to be used on the Certificate
 	IPAddresses []string `json:"ipAddresses,omitempty"`
+
+	// EmailAddresses is a list of email addresses to use in the Subject Alternative Names (SANs)
+	EmailAddresses []string `json:"emailAddresses,omitempty"`
+
+	// URIs is a list of URIs to use in the Subject Alternative Names (SANs)
+	URIs []string `json:"uris,omitempty"`
 
 	// SecretName is the name of the secret resource to store this secret in
 	SecretName string `json:"secretName"`

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -218,6 +218,17 @@ func (c *Controller) certificateMatchesSpec(crt *v1alpha1.Certificate, key crypt
 		errs = append(errs, fmt.Sprintf("DNS names on TLS certificate not up to date: %q", cert.DNSNames))
 	}
 
+	// validate the email SANs are correct
+	expectedEmailAddresses := pki.EMailAddressesForCertificate(crt)
+	if !util.EqualUnsorted(cert.EmailAddresses, expectedEmailAddresses) {
+		errs = append(errs, fmt.Sprintf("Email SANs on TLS certificate not up to date: %q", cert.EmailAddresses))
+	}
+
+	// validate the URI SANs are correct
+	if !util.EqualUnsorted(pki.URIsToString(cert.URIs), crt.Spec.URIs) {
+		errs = append(errs, fmt.Sprintf("URI SANs on TLS certificate not up to date: %q", cert.URIs))
+	}
+
 	// validate the ip addresses are correct
 	if !util.EqualUnsorted(pki.IPAddressesToString(cert.IPAddresses), crt.Spec.IPAddresses) {
 		errs = append(errs, fmt.Sprintf("IP addresses on TLS certificate not up to date: %q", pki.IPAddressesToString(cert.IPAddresses)))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
* Allows to configure email / URI Subject Alternative Names
* Explicitly use these SANs in the Vault issuer
* Makes it possible to exclude the common name from the SANs (was inconsistent w.r.t. Vault) 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1356

**Special notes for your reviewer**:

This is WIP in the sense that I would like feedback before investing more time. I also did not add any additional tests (yet) though the build passed locally and I did some initial tests in our cluster.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
When using the Vault issuer, the `exclude_cn_from_sans` parameter of the Vault PKI API now defaults to false to make it consistent in how conformance to the certificate spec is validated. This can now be explicitly configured on the `Certificate` resource (ExcludeCommonNameFromSANs)
```
